### PR TITLE
Fix interface class/name buffer over-read.

### DIFF
--- a/usbparse.c
+++ b/usbparse.c
@@ -416,8 +416,8 @@ static void AddInterface (Device *device, char *data)
 
 	interface = (DeviceInterface *)g_malloc0 (sizeof(DeviceInterface));
 
-	interface->class        = (gchar *)g_malloc0 ((INTERFACE_CLASS_SIZE) * sizeof(gchar));
-	interface->name         = (gchar *)g_malloc0 ((INTERFACE_DRIVERNAME_STRING_MAXLENGTH) * sizeof(gchar));
+	interface->class        = (gchar *)g_malloc0 ((INTERFACE_CLASS_SIZE + 1) * sizeof(gchar));
+	interface->name         = (gchar *)g_malloc0 ((INTERFACE_DRIVERNAME_STRING_MAXLENGTH + 1) * sizeof(gchar));
 
 	interface->interfaceNumber      = GetInt (data, INTERFACE_NUMBER_STRING, 10);
 	interface->alternateNumber      = GetInt (data, INTERFACE_ALTERNATESETTING_STRING, 10);


### PR DESCRIPTION
Class was mallocing 10 bytes, then GetString would do a strncpy
of 10 bytes into class, however strncpy was not null-terminating
the buffer. From the strncpy man page:

  Warning: If there is no null byte among the first n bytes of
    src, the string placed in dest will not be null-terminated.

Fix is to malloc an extra byte for the class and name buffers.

Signed-off-by: Michael Sartain mikesart@gmail.com
