### PR TITLE
Display correctly when a dark GTK+ theme is used

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -52,7 +52,7 @@ query_tooltip_cb(GtkWidget *widget, gint x, gint y,
 	/* Get the color, if it's red, set tooltip to indicate device has no driver. */
 	gtk_tree_model_get_iter(model, &iter, path);
 	gtk_tree_model_get(model, &iter, COLOR_COLUMN, &color, -1);
-	if (strncmp(color, "red", 4) == 0) {
+	if (color != NULL && strncmp(color, "red", 4) == 0) {
 		gtk_tooltip_set_text(tooltip, "This device has no attached driver");
 		return_val = TRUE;
 	}

--- a/usbtree.c
+++ b/usbtree.c
@@ -224,7 +224,7 @@ static void DisplayDevice (struct Device *parent, struct Device *device)
 	int		interfaceNum;
 	gboolean	driverAttached = TRUE;
 	gint		deviceAddr;
-	const gchar	*color = "black";
+	const gchar	*color = NULL;
 
 	if (device == NULL)
 		return;


### PR DESCRIPTION
Hello!
This fixes a tiny UI issue which made the app unreadable when the system was set to dark mode.

Before:
![image](https://user-images.githubusercontent.com/417468/191301119-42097689-36f1-42f3-a85f-2108c7ad70e1.png)
After:
![image](https://user-images.githubusercontent.com/417468/191301254-6b82314f-bb5a-4067-88f9-836c473fbad7.png)

This also doesn't break the app in light mode :-) I could have messed around with GtkStyleContext & Co, but setting a NULL color did the trick as well and was a lot simpler.

Thanks for considering this patch!