### PR TITLE
Add AppStream metadata

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,8 +31,10 @@ EXTRA_DIST = $(man_MANS) usbview_icon.svg usbview.desktop	\
 	LICENSES/GPL-2.0-only.txt
 
 desktopdir = $(datadir)/applications
+metainfodir = $(datadir)/metainfo
 if DESKTOP
 desktop_DATA = usbview.desktop
+metainfo_DATA = com.kroah.usbview.metainfo.xml
 endif
 
 icondir = $(datadir)/icons

--- a/com.kroah.usbview.metainfo.xml
+++ b/com.kroah.usbview.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.kroah.usbview</id>
+
+  <name>USBView</name>
+  <summary>A USB device tree viewer</summary>
+
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-2.0-only</project_license>
+
+  <description>
+    <p>
+      USBView is a small application to show what the device tree of the USB bus looks like.
+      It shows a graphical representation of the devices that are currently plugged in,
+      showing the topology of the USB bus.
+      It also displays information on each individual device on the bus.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">usbview.desktop</launchable>
+
+  <content_rating/>
+</component>


### PR DESCRIPTION
Hi!
This PR adds an [AppStream](https://www.freedesktop.org/wiki/Distributions/AppStream/) MetaInfo file to this project. The file augments the metadata already provided by the existing desktop-entry file so this application can be visible in modern software centers such as GNOME Software and KDE Discover.
It also assigns an unique ID to it, so the application is uniquely identifiable. The data is also translatable, but for a very technical app that itself is not translated, it probably isn't worth it to set up metadata localization.

The metadata can be created (or updated) using the MetaInfo Creator web tool: https://www.freedesktop.org/software/appstream/metainfocreator/#/
It can also be validated using `appstreamcli validate --strict --pedantic com.kroah.usbview.metainfo.xml` (the `appstreamcli` utility should be available in any Linux distribution, usually in a package called `appstream` or very similar).

Thank you for creating this tool, it's very handy in some circumstances!
Cheers,
    Matthias
