### PR TITLE
Icons: Make PNG/XPM transparent, hi-res

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,7 @@ endif
 $(icon_bitmaps_png): usbview_icon.svg
 	mkdir -p $$(dirname $@)
 if HAVE_CONVERT
-	$(CONVERT) -background none -density 300x300 -geometry $$(basename $$(dirname $$(dirname $@))) $< $@
+	$(CONVERT) -background none -density 300x300 -geometry $$(basename $$(dirname $$(dirname $@))) -density 96x96 $< $@
 else
 	echo "error: unable to generate $@ from $<"
 	exit 1
@@ -66,7 +66,7 @@ endif
 $(icon_bitmaps_xpm): usbview_icon.svg
 	mkdir -p $$(dirname $@)
 if HAVE_CONVERT
-	$(CONVERT) -background none -density 300x300 -geometry $$(basename $$(dirname $$(dirname $@))) $< $@
+	$(CONVERT) -background none -density 300x300 -geometry $$(basename $$(dirname $$(dirname $@))) -density 96x96 $< $@
 else
 	echo "error: unable to generate $@ from $<"
 	exit 1

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,7 @@ endif
 $(icon_bitmaps_png): usbview_icon.svg
 	mkdir -p $$(dirname $@)
 if HAVE_CONVERT
-	$(CONVERT) -geometry $$(basename $$(dirname $$(dirname $@))) $< $@
+	$(CONVERT) -background none -density 300x300 -geometry $$(basename $$(dirname $$(dirname $@))) $< $@
 else
 	echo "error: unable to generate $@ from $<"
 	exit 1
@@ -66,7 +66,7 @@ endif
 $(icon_bitmaps_xpm): usbview_icon.svg
 	mkdir -p $$(dirname $@)
 if HAVE_CONVERT
-	$(CONVERT) -geometry $$(basename $$(dirname $$(dirname $@))) $< $@
+	$(CONVERT) -background none -density 300x300 -geometry $$(basename $$(dirname $$(dirname $@))) $< $@
 else
 	echo "error: unable to generate $@ from $<"
 	exit 1


### PR DESCRIPTION
Extend the ImageMagick `convert` commands for generating icon bitmaps:
- Add `-background none`, to render with background transparency.
- Add `-density 300x300`, to render larger sizes at full resolution.

Because the SVG's internal coordinate system is only sized for 64x64 pixels, ImageMagick will render at that size and then scale the _bitmap_ up, when outputting larger image sizes. Increasing the DPI using `-density` allows it to upscale the SVG vectors at full resolution.

#### Comparison: 256x256 `usbview.png` from this branch vs. `master`, atop solid red
![usbview-icon-compare](https://github.com/gregkh/usbview/assets/538020/05efb52f-8da6-4c1f-9411-faeab55feacb)
