### PR TITLE
port from GTK3 to GTK4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@
 /missing
 /stamp-h1
 /usbview
-/usbview_icon.xpm
 Makefile
 Makefile.in

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
 # Copyright (c) 2022-2023 Greg Kroah-Hartman <greg@kroah.com>
 #
 
+version 3.2
+	- port to Gtk4
+
 version 3.1
 	- remove now-unnecessary policykit/pkexec support
 	- appstream metadata added

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,8 +24,6 @@ usbview_SOURCES =		\
 	ccan/list/list.h		\
 	usbview_logo.xpm
 
-interface.o: $(icon_bitmaps_xpm)
-
 EXTRA_DIST = $(man_MANS) usbview_icon.svg usbview.desktop	\
 	usbview_logo.xcf				\
 	com.kroah.usbview.metainfo.xml			\
@@ -48,22 +46,11 @@ icon_bitmaps_png = \
        hicolor/64x64/apps/usbview.png \
        hicolor/256x256/apps/usbview.png
 
-icon_bitmaps_xpm = hicolor/64x64/apps/usbview_icon.xpm
-
 if ICONS
 nobase_icon_DATA = $(icon_scalable) $(icon_bitmaps_png)
 endif
 
 $(icon_bitmaps_png): usbview_icon.svg
-	mkdir -p $$(dirname $@)
-if HAVE_CONVERT
-	$(CONVERT) -background none -density 300x300 -geometry $$(basename $$(dirname $$(dirname $@))) -density 96x96 $< $@
-else
-	echo "error: unable to generate $@ from $<"
-	exit 1
-endif
-
-$(icon_bitmaps_xpm): usbview_icon.svg
 	mkdir -p $$(dirname $@)
 if HAVE_CONVERT
 	$(CONVERT) -background none -density 300x300 -geometry $$(basename $$(dirname $$(dirname $@))) -density 96x96 $< $@
@@ -78,7 +65,7 @@ $(icon_scalable): usbview_icon.svg
 	mkdir -p $$(dirname $@)
 	cp $< $@
 
-CLEANFILES = $(icon_scalable) $(icon_bitmaps_png) $(icon_bitmaps_xpm)
+CLEANFILES = $(icon_scalable) $(icon_bitmaps_png)
 
 # gtk_update_icon_cache = gtk-update-icon-cache -f -t $(datadir)/icons/hicolor; gtk-update-icon-cache -f -t $(datadir)/icons/HighContrast
 #

--- a/callbacks.c
+++ b/callbacks.c
@@ -14,14 +14,15 @@
 
 void on_buttonClose_clicked (GtkButton *button, gpointer user_data)
 {
-	gtk_main_quit();
+	if (mainloop && g_main_loop_is_running(mainloop))
+		g_main_loop_quit(mainloop);
 }
 
 
 gboolean on_window1_delete_event (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
-	gtk_main_quit();
-
+	if (mainloop && g_main_loop_is_running(mainloop))
+		g_main_loop_quit(mainloop);
 	return FALSE;
 }
 
@@ -34,10 +35,12 @@ void on_buttonRefresh_clicked (GtkButton *button, gpointer user_data)
 
 void on_buttonAbout_clicked (GtkButton *button, gpointer user_data)
 {
-	GdkPixbuf *logo;
+	GdkPixbuf *pixbuf;
+	GdkTexture *logo;
 	gchar *authors[] = { "Greg Kroah-Hartman <greg@kroah.com>", NULL };
 
-	logo = gdk_pixbuf_new_from_xpm_data ((const char **)usbview_logo_xpm);
+	pixbuf = gdk_pixbuf_new_from_xpm_data ((const char **)usbview_logo_xpm);
+	logo = gdk_texture_new_for_pixbuf (pixbuf);
 	gtk_show_about_dialog (GTK_WINDOW (windowMain),
 		"logo", logo,
 		"program-name", "usbview",
@@ -48,6 +51,7 @@ void on_buttonAbout_clicked (GtkButton *button, gpointer user_data)
 		"copyright", "Copyright © 1999-2012, 2021-2022",
 		"authors", authors,
 		NULL);
+	g_object_unref (pixbuf);
 	g_object_unref (logo);
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,8 +4,8 @@ dnl Process this file with autoconf to produce a configure script.
 
 # Prologue.
 
-AC_PREREQ([2.69])
-AC_INIT([USBView],[3.1],[Greg Kroah-Hartman <greg@kroah.com>],[usbview],[http://www.kroah.com/linux-usb/])
+AC_PREREQ([2.72])
+AC_INIT([USBView],[3.2],[Greg Kroah-Hartman <greg@kroah.com>],[usbview],[http://www.kroah.com/linux-usb/])
 AC_CONFIG_SRCDIR([usbtree.c])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall])
@@ -47,7 +47,7 @@ AM_CONDITIONAL(ICONS,[test x${icons} = xyes])
 # Checks for libraries.
 
 AC_SEARCH_LIBS([strerror],[cposix])
-PKG_CHECK_MODULES([GTK], [gtk+-3.0 >= 3.0])
+PKG_CHECK_MODULES([GTK], [gtk4 >= 4.0])
 AC_SUBST([GTK_FLAGS])
 AC_SUBST([GTK_LIBS])
 

--- a/interface.c
+++ b/interface.c
@@ -20,6 +20,7 @@ GtkTreeStore *treeStore;
 GtkTextBuffer *textDescriptionBuffer;
 GtkWidget *textDescriptionView;
 GtkWidget *windowMain;
+GMainLoop *mainloop;
 static GtkTreeViewColumn *treeColumn;
 
 int timer;
@@ -37,23 +38,24 @@ create_windowMain ()
 	GdkPixbuf *icon;
 	GtkCellRenderer *treeRenderer;
 
-	windowMain = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+	windowMain = gtk_window_new ();
 	gtk_widget_set_name (windowMain, "windowMain");
 	gtk_window_set_title (GTK_WINDOW (windowMain), "USB Viewer");
 	gtk_window_set_default_size (GTK_WINDOW (windowMain), 600, 300);
 
 	icon = gdk_pixbuf_new_from_xpm_data((const char **)usbview_icon);
-	gtk_window_set_icon(GTK_WINDOW(windowMain), icon);
+	gtk_window_set_icon_name(GTK_WINDOW(windowMain), "usbview");
 
 	vbox1 = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 	gtk_widget_set_name (vbox1, "vbox1");
-	gtk_widget_show (vbox1);
-	gtk_container_add (GTK_CONTAINER (windowMain), vbox1);
+	gtk_window_set_child (GTK_WINDOW (windowMain), vbox1);
 
 	hpaned1 = gtk_paned_new (GTK_ORIENTATION_HORIZONTAL);
 	gtk_widget_set_name (hpaned1, "hpaned1");
-	gtk_widget_show (hpaned1);
-	gtk_box_pack_start (GTK_BOX (vbox1), hpaned1, TRUE, TRUE, 0);
+	gtk_widget_set_hexpand (hpaned1, TRUE);
+	gtk_widget_set_vexpand (hpaned1, TRUE);
+	gtk_paned_set_position (GTK_PANED (hpaned1), 300);
+	gtk_box_append (GTK_BOX (vbox1), hpaned1);
 
 	treeStore = gtk_tree_store_new (N_COLUMNS,
 				G_TYPE_STRING,	/* NAME_COLUMN */
@@ -74,14 +76,16 @@ create_windowMain ()
 	);
 
 	gtk_widget_set_name (treeUSB, "treeUSB");
-	gtk_widget_show (treeUSB);
-	gtk_paned_pack1 (GTK_PANED (hpaned1), treeUSB, FALSE, FALSE);
+	gtk_widget_set_hexpand (treeUSB, TRUE);
+	gtk_widget_set_vexpand (treeUSB, TRUE);
+	gtk_paned_set_start_child (GTK_PANED (hpaned1), treeUSB);
 
-	scrolledwindow1 = gtk_scrolled_window_new (NULL, NULL);
+	scrolledwindow1 = gtk_scrolled_window_new ();
 	gtk_widget_set_name (scrolledwindow1, "scrolledwindow1");
+	gtk_widget_set_hexpand (scrolledwindow1, TRUE);
+	gtk_widget_set_vexpand (scrolledwindow1, TRUE);
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolledwindow1), GTK_POLICY_NEVER, GTK_POLICY_ALWAYS);
-	gtk_widget_show (scrolledwindow1);
-	gtk_paned_pack2 (GTK_PANED (hpaned1), scrolledwindow1, TRUE, FALSE);
+	gtk_paned_set_end_child (GTK_PANED (hpaned1), scrolledwindow1);
 
 	textDescriptionBuffer = gtk_text_buffer_new(NULL);
 	//textDescription = gtk_text_new (NULL, NULL);
@@ -89,39 +93,33 @@ create_windowMain ()
 	gtk_widget_set_name (textDescriptionView, "textDescription");
 	gtk_text_view_set_editable(GTK_TEXT_VIEW(textDescriptionView), FALSE);
 	gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(textDescriptionView), FALSE);
-	gtk_widget_show (textDescriptionView);
-	gtk_container_add (GTK_CONTAINER (scrolledwindow1), textDescriptionView);
+	gtk_scrolled_window_set_child (GTK_SCROLLED_WINDOW (scrolledwindow1), textDescriptionView);
 
-	hbuttonbox1 = gtk_button_box_new (GTK_ORIENTATION_HORIZONTAL);
+	hbuttonbox1 = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
 	gtk_widget_set_name (hbuttonbox1, "hbuttonbox1");
-	gtk_widget_show (hbuttonbox1);
-	gtk_box_pack_start (GTK_BOX (vbox1), hbuttonbox1, FALSE, FALSE, 5);
+	gtk_widget_set_halign (hbuttonbox1, GTK_ALIGN_END);
+	gtk_widget_set_margin_top (hbuttonbox1, 5);
+	gtk_widget_set_margin_bottom (hbuttonbox1, 5);
+	gtk_widget_set_margin_start (hbuttonbox1, 5);
+	gtk_widget_set_margin_end (hbuttonbox1, 5);
+	gtk_box_append (GTK_BOX (vbox1), hbuttonbox1);
 	//gtk_button_box_set_spacing (GTK_BUTTON_BOX (hbuttonbox1), 10);
 	//gtk_button_box_set_child_size (GTK_BUTTON_BOX (hbuttonbox1), 50, 25);
 	//gtk_button_box_set_child_ipadding (GTK_BUTTON_BOX (hbuttonbox1), 25, 10);
 
 	buttonRefresh = gtk_button_new_with_label("Refresh");
 	gtk_widget_set_name (buttonRefresh, "buttonRefresh");
-	gtk_widget_show (buttonRefresh);
-	gtk_container_add (GTK_CONTAINER (hbuttonbox1), buttonRefresh);
-	gtk_container_set_border_width (GTK_CONTAINER (buttonRefresh), 4);
-	gtk_widget_set_can_default (buttonRefresh, TRUE);
+	gtk_box_append (GTK_BOX (hbuttonbox1), buttonRefresh);
 
 	buttonAbout = gtk_button_new_with_label("About");
 	gtk_widget_set_name (buttonAbout, "buttonAbout");
-	gtk_widget_show (buttonAbout);
-	gtk_container_add (GTK_CONTAINER (hbuttonbox1), buttonAbout);
-	gtk_container_set_border_width (GTK_CONTAINER (buttonAbout), 4);
-	gtk_widget_set_can_default (buttonAbout, TRUE);
+	gtk_box_append (GTK_BOX (hbuttonbox1), buttonAbout);
 
 	buttonClose = gtk_button_new_with_label("Quit");
 	gtk_widget_set_name (buttonClose, "buttonClose");
-	gtk_widget_show (buttonClose);
-	gtk_container_add (GTK_CONTAINER (hbuttonbox1), buttonClose);
-	gtk_container_set_border_width (GTK_CONTAINER (buttonClose), 4);
-	gtk_widget_set_can_default (buttonClose, TRUE);
+	gtk_box_append (GTK_BOX (hbuttonbox1), buttonClose);
 
-	g_signal_connect (G_OBJECT (windowMain), "delete_event",
+	g_signal_connect (G_OBJECT (windowMain), "close-request",
 			    G_CALLBACK (on_window1_delete_event),
 			    NULL);
 	g_signal_connect (G_OBJECT (buttonRefresh), "clicked",

--- a/interface.c
+++ b/interface.c
@@ -13,7 +13,6 @@
 #include <gtk/gtk.h>
 
 #include "usbtree.h"
-#include "hicolor/64x64/apps/usbview_icon.xpm"
 
 GtkWidget *treeUSB;
 GtkTreeStore *treeStore;
@@ -35,7 +34,6 @@ create_windowMain ()
 	GtkWidget *buttonRefresh;
 	GtkWidget *buttonClose;
 	GtkWidget *buttonAbout;
-	GdkPixbuf *icon;
 	GtkCellRenderer *treeRenderer;
 
 	windowMain = gtk_window_new ();
@@ -43,7 +41,6 @@ create_windowMain ()
 	gtk_window_set_title (GTK_WINDOW (windowMain), "USB Viewer");
 	gtk_window_set_default_size (GTK_WINDOW (windowMain), 600, 300);
 
-	icon = gdk_pixbuf_new_from_xpm_data((const char **)usbview_icon);
 	gtk_window_set_icon_name(GTK_WINDOW(windowMain), "usbview");
 
 	vbox1 = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);

--- a/main.c
+++ b/main.c
@@ -17,7 +17,7 @@ int main (int argc, char *argv[])
 {
 	GtkWidget *window1;
 
-	gtk_init (&argc, &argv);
+	gtk_init ();
 
 	initialize_stuff();
 
@@ -27,10 +27,15 @@ int main (int argc, char *argv[])
 	 * the project. Delete any components that you don't want shown initially.
 	 */
 	window1 = create_windowMain ();
-	gtk_widget_show (window1);
+	gtk_widget_set_visible (window1, TRUE);
 
 	LoadUSBTree(0);
-	gtk_main ();
+	
+	/* Create and run main loop */
+	mainloop = g_main_loop_new (NULL, FALSE);
+	g_main_loop_run (mainloop);
+	g_main_loop_unref (mainloop);
+	
 	return 0;
 }
 

--- a/sysfs.c
+++ b/sysfs.c
@@ -26,6 +26,11 @@
 #include "sysfs.h"
 #include "ccan/list/list.h"
 
+// PATH_MAX is not defined in GNU Hurd. Here, 1000 is way more than sufficient.
+#ifndef PATH_MAX
+#define PATH_MAX 1000
+#endif
+
 struct Device *rootDevice = NULL;
 static struct DeviceBandwidth *currentBandwidth = NULL;
 

--- a/usbtree.c
+++ b/usbtree.c
@@ -67,7 +67,7 @@ static void PopulateListBox (int deviceId)
 
 	/* freeze the display */
 	/* this keeps the annoying scroll from happening */
-	gtk_widget_freeze_child_notify(textDescriptionView);
+	/* gtk_widget_freeze_child_notify is removed in GTK4 */
 
 	string = (char *)g_malloc (1000);
 
@@ -194,7 +194,7 @@ static void PopulateListBox (int deviceId)
 	}
 
 	/* thaw the display */
-	gtk_widget_thaw_child_notify(textDescriptionView);
+	/* gtk_widget_thaw_child_notify is removed in GTK4 */
 
 	/* clean up our string */
 	g_free (string);
@@ -291,7 +291,7 @@ void LoadUSBTree (int refresh)
 		DisplayDevice (rootDevice, rootDevice->child[i]);
 	}
 
-	gtk_widget_show (treeUSB);
+	gtk_widget_set_visible (treeUSB, TRUE);
 
 	gtk_tree_view_expand_all (GTK_TREE_VIEW (treeUSB));
 

--- a/usbtree.h
+++ b/usbtree.h
@@ -19,6 +19,7 @@ extern GtkWidget	*treeUSB;
 extern GtkWidget	*textDescriptionView;
 extern GtkTextBuffer	*textDescriptionBuffer;
 extern GtkWidget	*windowMain;
+extern GMainLoop	*mainloop;
 
 void LoadUSBTree(int refresh);
 void initialize_stuff(void);


### PR DESCRIPTION
Copilot did all the work, I just criticised and squashed.

Two remaining loose ends:

* The "about" dialog has the logo too small. This is intrinsic to Gtk4 which allocates 128×128 pixels to the logo. Scaling it doesn't help.

* There are some deprecated procedure calls, in particular for the tree stuff. Porting to the new approved alternative would be work.